### PR TITLE
Added Reset() to Ticker

### DIFF
--- a/clock/frozen.go
+++ b/clock/frozen.go
@@ -190,6 +190,10 @@ func (t *frozenTicker) Stop() {
 	t.t.Stop()
 }
 
+func (t *frozenTicker) Reset(d time.Duration) {
+	t.t.Reset(d)
+}
+
 func (ft *frozenTime) NewTicker(d time.Duration) Ticker {
 	if d <= 0 {
 		panic(errors.New("non-positive interval for NewTicker"))

--- a/clock/frozen_test.go
+++ b/clock/frozen_test.go
@@ -212,6 +212,12 @@ func (s *FrozenSuite) TestTicker() {
 	clock.Advance(1)
 	s.Require().Equal(<-t.C(), s.epoch.Add(900))
 
+	t.Reset(200)
+	clock.Advance(100)
+	s.assertNotFired(t.C())
+	clock.Advance(100)
+	s.Require().Equal(<-t.C(), s.epoch.Add(1100))
+
 	t.Stop()
 	clock.Advance(300)
 	s.assertNotFired(t.C())

--- a/clock/interface.go
+++ b/clock/interface.go
@@ -11,6 +11,7 @@ type Timer interface {
 
 // Ticker see time.Ticker.
 type Ticker interface {
+	Reset(d time.Duration)
 	C() <-chan time.Time
 	Stop()
 }

--- a/clock/system.go
+++ b/clock/system.go
@@ -56,6 +56,10 @@ func (t *systemTicker) Stop() {
 	t.t.Stop()
 }
 
+func (t *systemTicker) Reset(d time.Duration) {
+	t.t.Reset(d)
+}
+
 func (st *systemTime) NewTicker(d time.Duration) Ticker {
 	t := time.NewTicker(d)
 	return &systemTicker{t}


### PR DESCRIPTION
## Purpose
time.Ticker.Reset() is part of the standard library, but missing from tackle/clock