### PR TITLE
autotls: accept *slog.Logger, deprecate StandardLogger/NoOpLogger

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,7 +29,7 @@ jobs:
         run: go mod tidy && git diff --exit-code
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           skip-cache: true # cache/restore is done by actions/setup-go@v3 step

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCI_LINT_VERSION: v1.61.0
+  GOLANGCI_LINT_VERSION: v2.1.0
 
 jobs:
   lint:
@@ -29,7 +29,7 @@ jobs:
         run: go mod tidy && git diff --exit-code
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           skip-cache: true # cache/restore is done by actions/setup-go@v3 step

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  GOLANGCI_LINT_VERSION: v2.1.0
+  GOLANGCI_LINT_VERSION: v2.11.4
 
 jobs:
   lint:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.x
+          - 1.26.x
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := build
 LINT = $(GOPATH)/bin/golangci-lint
-LINT_VERSION = v1.61.0
+LINT_VERSION = v2.1.0
 
 $(LINT): ## Download Go linter
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(LINT_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := build
 LINT = $(GOPATH)/bin/golangci-lint
-LINT_VERSION = v2.1.0
+LINT_VERSION = v2.11.4
 
 $(LINT): ## Download Go linter
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(LINT_VERSION)

--- a/autotls/log.go
+++ b/autotls/log.go
@@ -1,5 +1,10 @@
 package autotls
 
+// StandardLogger is retained for backward compatibility. New code should use
+// *slog.Logger, which satisfies this interface structurally and can be
+// assigned to autotls.Config.Logger directly.
+//
+// Deprecated: use *slog.Logger.
 type StandardLogger interface {
 	Error(msg string, args ...any)
 	Info(msg string, args ...any)
@@ -7,6 +12,10 @@ type StandardLogger interface {
 	Warn(msg string, args ...any)
 }
 
+// NoOpLogger is retained for backward compatibility. New code that needs a
+// silent logger should use slog.New(slog.DiscardHandler).
+//
+// Deprecated: use slog.New(slog.DiscardHandler).
 type NoOpLogger struct{}
 
 func (NoOpLogger) Error(msg string, args ...any) {}

--- a/autotls/tls.go
+++ b/autotls/tls.go
@@ -27,6 +27,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net"
 	"os"
@@ -87,7 +88,9 @@ type Config struct {
 	// presented by the server and any host name in that certificate.
 	InsecureSkipVerify bool
 
-	// (Optional) A Logger which implements the declared logger interface (typically *logrus.Entry)
+	// (Optional) A logger used to emit diagnostic messages. Defaults to a logger
+	// backed by slog.DiscardHandler (silent) when left nil. Any *slog.Logger can
+	// be assigned here directly — it satisfies StandardLogger structurally.
 	Logger StandardLogger
 
 	// (Optional) The CA Certificate in PEM format. Used if CaFile is unset
@@ -223,7 +226,7 @@ func Setup(conf *Config) error {
 		return err
 	}
 
-	set.Default(&conf.Logger, &NoOpLogger{})
+	set.Default(&conf.Logger, slog.New(slog.DiscardHandler))
 
 	// If generated TLS certs requested
 	if conf.AutoTLS {

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/kapetan-io/tackle
 // tackle requires 1.22 or greater. 1.22 fixes closure scope issues with previous golang versions.
 // This is required for proper use of `wait.Group` and `wait.FanOut`.
 // See https://go.dev/blog/loopvar-preview for details
-go 1.23.0
+go 1.26
 
-toolchain go1.23.7
+toolchain go1.26.2
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/retry/testing.go
+++ b/retry/testing.go
@@ -27,7 +27,7 @@ func (s *TestResults) FailNow() {
 
 func (s *TestResults) Report(t TestingT) {
 	for _, failure := range s.Failures {
-		t.Errorf(failure)
+		t.Errorf("%s", failure)
 	}
 }
 
@@ -70,7 +70,7 @@ func UntilConnect(t TestingT, a int, d time.Duration, addr string) {
 		if err != nil {
 			continue
 		}
-		conn.Close()
+		_ = conn.Close()
 		time.Sleep(d)
 		return
 	}

--- a/retry/testing_test.go
+++ b/retry/testing_test.go
@@ -22,7 +22,7 @@ func TestUntilConnect(t *testing.T) {
 	go func() {
 		cn, err := ln.Accept()
 		require.NoError(t, err)
-		cn.Close()
+		_ = cn.Close()
 	}()
 	// Wait until we can connect, then continue with the test
 	retry.UntilConnect(t, 10, time.Millisecond*100, ln.Addr().String())
@@ -39,7 +39,7 @@ func TestUntilPass(t *testing.T) {
 			// Set the value
 			value = r.FormValue("value")
 		} else {
-			fmt.Fprintln(w, value)
+			_, _ = fmt.Fprintln(w, value)
 		}
 	}))
 	defer ts.Close()


### PR DESCRIPTION
### Purpose
Enable `autotls.Config` to accept a `*slog.Logger` directly so downstream consumers (notably the scaffold framework) can wire `log/slog` through without a shim. The migration is intentionally non-breaking: `*slog.Logger` structurally satisfies the existing `StandardLogger` interface, so no field-type change or v2 module bump is required. Existing callers that implemented `StandardLogger` themselves continue to compile unchanged.

### Implementation
- `autotls/log.go` — mark `StandardLogger` and `NoOpLogger` with godoc `// Deprecated:` comments steering new code at `*slog.Logger` and `slog.New(slog.DiscardHandler)`. Both types remain exported to preserve source compatibility.
- `autotls/tls.go` — add `log/slog` import; swap `Setup`'s default logger from `&NoOpLogger{}` to `slog.New(slog.DiscardHandler)`; replace the stale `*logrus.Entry` comment on `Config.Logger` with text documenting the silent default and the `*slog.Logger` assignment pattern.
- `go.mod` — bump to `go 1.26` / `toolchain go1.26.2` (required because `slog.DiscardHandler` was added in Go 1.24; chosen to match scaffold's target).
- `retry/testing.go`, `retry/testing_test.go` — fix pre-existing errcheck and printf findings (`_ = conn.Close()`, `_ = cn.Close()`, `_, _ = fmt.Fprintln(...)`, `t.Errorf("%s", failure)`) that the stricter Go 1.26 vet and linter unmasked. These are the minimum changes needed to keep `make ci` green after the toolchain bump.