### PR TITLE
retry: respect Max when computing BackOff and Explain output

### DIFF
--- a/retry/retry.go
+++ b/retry/retry.go
@@ -64,6 +64,9 @@ type IntervalBackOff struct {
 
 func (b IntervalBackOff) Next(attempts int) time.Duration {
 	d := time.Duration(float64(b.Min) * math.Pow(b.Factor, float64(attempts)))
+	if d > b.Max {
+		d = b.Max
+	}
 	if b.Rand != nil {
 		upper := float64(d) + (float64(d) * b.Jitter)
 		lower := float64(d) - (float64(d) * b.Jitter)
@@ -100,8 +103,11 @@ type BackOffExplain struct {
 func (b IntervalBackOff) Explain(attempt int) BackOffExplain {
 	// Calc the power of the factor based on attempts
 	e := BackOffExplain{Attempt: attempt, PowerOf: math.Pow(b.Factor, float64(attempt))}
-	// Backoff is the minimum multiplied by the power
+	// Backoff is the minimum multiplied by the power, capped at Max
 	e.BackOff = time.Duration(float64(b.Min) * e.PowerOf)
+	if e.BackOff > b.Max {
+		e.BackOff = b.Max
+	}
 
 	// If we asked for jitter
 	if b.Rand != nil {
@@ -109,6 +115,12 @@ func (b IntervalBackOff) Explain(attempt int) BackOffExplain {
 		e.RangeMin = time.Duration(float64(e.BackOff) - percent)
 		e.RangeMax = time.Duration(float64(e.BackOff) + percent)
 		e.WithJitter = time.Duration(float64(e.RangeMin) + b.Rand.Float64()*float64(e.RangeMax-e.RangeMin))
+		if e.WithJitter > b.Max {
+			e.WithJitter = b.Max
+		}
+		if e.WithJitter < b.Min {
+			e.WithJitter = b.Min
+		}
 	}
 	return e
 }

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -205,6 +205,48 @@ func TestIntervalBackOff(t *testing.T) {
 	assert.Equal(t, 60.0, p.Next(12).Seconds())
 }
 
+func TestIntervalBackOffRespectsMax(t *testing.T) {
+	t.Run("no-jitter", func(t *testing.T) {
+		p := retry.IntervalBackOff{
+			Min:    500 * time.Millisecond,
+			Max:    20 * time.Hour,
+			Factor: 2.0,
+		}
+		for attempt := 0; attempt < 30; attempt++ {
+			assert.LessOrEqual(t, p.Next(attempt), p.Max)
+		}
+	})
+
+	t.Run("with-jitter", func(t *testing.T) {
+		p := retry.IntervalBackOff{
+			Rand:   rand.New(rand.NewSource(0)),
+			Min:    500 * time.Millisecond,
+			Max:    20 * time.Hour,
+			Factor: 2.0,
+			Jitter: 0.5,
+		}
+		for attempt := 0; attempt < 30; attempt++ {
+			assert.LessOrEqual(t, p.Next(attempt), p.Max)
+		}
+	})
+
+	t.Run("explain", func(t *testing.T) {
+		p := retry.IntervalBackOff{
+			Rand:   rand.New(rand.NewSource(0)),
+			Min:    500 * time.Millisecond,
+			Max:    20 * time.Hour,
+			Factor: 2.0,
+			Jitter: 0.5,
+		}
+		for attempt := 0; attempt < 30; attempt++ {
+			e := p.Explain(attempt)
+			assert.LessOrEqual(t, e.BackOff, p.Max)
+			assert.LessOrEqual(t, e.WithJitter, p.Max)
+			assert.LessOrEqual(t, e.RangeMin, p.Max)
+		}
+	})
+}
+
 func TestIntervalBackOffWithJitter(t *testing.T) {
 	p := retry.IntervalBackOff{
 		Rand:   rand.New(rand.NewSource(0)),


### PR DESCRIPTION
### Purpose
The `retry` CLI (`cmd/retry`) was producing `BackOff` values that grew unbounded across attempts and ignored the user-supplied `-max` argument. For example `retry -attempts 30 -min 500ms -max 20h -factor 2.0 -jitter 0.5` produced values up to `74565h24m16s` instead of capping at `20h`. This PR makes both `IntervalBackOff.Next()` and `IntervalBackOff.Explain()` honor `Max` consistently.

### Implementation
- `retry/retry.go` — `Next()`: cap base `d` at `Max` before computing jitter, so jitter is centered on the capped value rather than an unbounded one. The post-jitter `[Min, Max]` clamp is retained as a safety net for asymmetric jitter ranges.
- `retry/retry.go` — `Explain()`: cap `BackOff` at `Max` before computing the jitter range, and clamp `WithJitter` to `[Min, Max]` to mirror `Next()`. Previously `Explain()` applied no cap at all, which is what produced the unbounded CLI output.
- `retry/retry_test.go` — added `TestIntervalBackOffRespectsMax` covering 30 attempts that exceed `Max`, asserting `Next()` (with and without jitter) and `Explain()` outputs stay within `Max`. Existing tests are unchanged and still pass since their inputs stay below the cap.